### PR TITLE
Dragging

### DIFF
--- a/card_collision/card_collision.tscn
+++ b/card_collision/card_collision.tscn
@@ -1,0 +1,26 @@
+[gd_scene load_steps=3 format=3 uid="uid://dda64qmj6m6ts"]
+
+[sub_resource type="GDScript" id="GDScript_ixllw"]
+script/source = "extends StaticBody2D
+
+
+
+"
+
+[sub_resource type="RectangleShape2D" id="RectangleShape2D_6fwo3"]
+size = Vector2(96, 138)
+
+[node name="deck" type="StaticBody2D" groups=["dropable"]]
+script = SubResource("GDScript_ixllw")
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+position = Vector2(49, 70)
+shape = SubResource("RectangleShape2D_6fwo3")
+debug_color = Color(0.776471, 0.403922, 0.482353, 0.419608)
+
+[node name="ColorRect" type="ColorRect" parent="."]
+offset_right = 97.0
+offset_bottom = 140.0
+color = Color(1, 1, 1, 0.129412)
+
+[connection signal="mouse_entered" from="." to="." method="_on_mouse_entered"]

--- a/card_ui/card_ui.gd
+++ b/card_ui/card_ui.gd
@@ -1,46 +1,22 @@
 extends Node2D
 
-var dragging = false
 var mouse_in = false
-var newPos: Vector2
-var draggingDistance
-var dir
+var selected = false
+var in_droppable
 
-# Called when the node enters the scene tree for the first time.
-func _ready():
-	pass
-	#var cardSize = size
-	#$Area2D/CardCollision.scale = cardSize
-
-	# This works for checking if a node is draggable.
-	#var card = get_node("Player1/CardUI1")
-	#print(card.is_in_group("draggable"))
-
-func _input(event):
-	if event is InputEventMouseButton:
-		if event.is_pressed() && mouse_in:
-			draggingDistance = position.distance_to(get_viewport().get_mouse_position())
-			dir = (get_viewport().get_mouse_position() - position).normalized()
-			dragging = true
-			newPos = get_viewport().get_mouse_position() - draggingDistance * dir
-		else:
-			dragging = false
-			
-	elif event is InputEventMouseMotion:
-		if dragging:
-			newPos = get_viewport().get_mouse_position() - draggingDistance * dir
-
-func _physics_process(delta):
-	if dragging:
-			move_child($".", 200)
-		#move_and_slide((newPos - position) * Vector2(30, 30))
-
-	
 func _process(delta):
-	pass	
+	pass
 
-func _on_mouse_entered():
+# handle input for card dragging
+func _input(event):
+	if Input.is_action_just_pressed("left-click") and mouse_in:
+		selected = true
+	if Input.is_action_just_released("left-click"):
+		selected = false
+	
+func _on_area_2d_mouse_entered():
 	mouse_in = true
 
-func _on_mouse_exited():
+func _on_area_2d_mouse_exited():
 	mouse_in = false
+

--- a/card_ui/card_ui.tscn
+++ b/card_ui/card_ui.tscn
@@ -4,22 +4,30 @@
 [ext_resource type="Texture2D" uid="uid://ben7qqx34vpkq" path="res://ass/cards/card_back.png" id="2_jcrdb"]
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_rywg1"]
-size = Vector2(97, 140)
+size = Vector2(100, 142)
 
 [node name="CardUI" type="Node2D" groups=["draggable"]]
+z_index = 2
+position = Vector2(-3, -2)
 script = ExtResource("2_1pg6x")
 
 [node name="TextureRect" type="TextureRect" parent="."]
+offset_left = 1.0
+offset_top = 1.0
 offset_right = 168.0
-offset_bottom = 240.0
+offset_bottom = 239.0
 scale = Vector2(0.6, 0.6)
 texture = ExtResource("2_jcrdb")
 expand_mode = 4
 
 [node name="Area2D" type="Area2D" parent="."]
+position = Vector2(3, 1)
 collision_mask = 2
 monitorable = false
 
 [node name="CardCollision" type="CollisionShape2D" parent="Area2D"]
-position = Vector2(50.5, 72)
+position = Vector2(48, 71)
 shape = SubResource("RectangleShape2D_rywg1")
+
+[connection signal="mouse_entered" from="Area2D" to="." method="_on_area_2d_mouse_entered"]
+[connection signal="mouse_exited" from="Area2D" to="." method="_on_area_2d_mouse_exited"]

--- a/project.godot
+++ b/project.godot
@@ -19,6 +19,14 @@ config/features=PackedStringArray("4.2", "Forward Plus")
 window/size/viewport_width=1920
 window/size/viewport_height=1080
 
+[input]
+
+left-click={
+"deadzone": 0.5,
+"events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
+]
+}
+
 [layer_names]
 
 2d_physics/layer_1="card_target_selector"

--- a/scenes/SinglePlayer.gd
+++ b/scenes/SinglePlayer.gd
@@ -8,13 +8,24 @@ var values = ["02", "03", "04", "05", "06", "07", "08", "09", "10", "A"]
 var player_deck = []
 var num_of_played = 0
 
-var blitz_pile = 10 # All players start with 10 cards in the blitz pile
+var card1
+var card2
+var card3
+var card4
+var hand = []
+
+const blitz_pile_size = 10 # All players start with 10 cards in the blitz pile
 
 # make a random num generator
 var random = RandomNumberGenerator.new()
 
 # On scene Load
 func _ready():
+	card1 = get_node("Player1/CardUI1")
+	card2 = get_node("Player1/CardUI2")
+	card3 = get_node("Player1/CardUI3")
+	card4 = get_node("Player1/CardUI4")
+	hand = [card1, card2, card3, card4]
 	
 	# holds AI decks
 	var ai_deck1 = []
@@ -40,7 +51,13 @@ func _ready():
 
 # Game Logic and called every frame
 func _process(delta):
-	pass
+	
+	# Handle dragging
+	for i  in len(hand):
+		if hand[i].selected:
+			hand[i].set_global_position(get_local_mouse_position() - Vector2(50,50))
+			hand[i].z_index = 2 # set above other cards.
+			
 # <------------------------------------------------------------------------------>
 # HELPERS AND BUTTONS BELOW
 

--- a/scenes/SinglePlayer.tscn
+++ b/scenes/SinglePlayer.tscn
@@ -143,19 +143,19 @@ position = Vector2(1038, 500)
 position = Vector2(136, 209)
 
 [node name="deck_collision3" parent="Container" instance=ExtResource("5_xtag3")]
-position = Vector2(298, 270)
+position = Vector2(374, 234)
 
 [node name="deck_collision4" parent="Container" instance=ExtResource("5_xtag3")]
-position = Vector2(859, 356)
+position = Vector2(876, 350)
 
 [node name="deck_collision5" parent="Container" instance=ExtResource("5_xtag3")]
-position = Vector2(1066, 77)
+position = Vector2(1172, 126)
 
 [node name="deck_collision6" parent="Container" instance=ExtResource("5_xtag3")]
-position = Vector2(785, 132)
+position = Vector2(947, 94)
 
 [node name="deck_collision7" parent="Container" instance=ExtResource("5_xtag3")]
-position = Vector2(596, 374)
+position = Vector2(637, 370)
 
 [node name="deck_collision8" parent="Container" instance=ExtResource("5_xtag3")]
 position = Vector2(401, 489)
@@ -164,13 +164,13 @@ position = Vector2(401, 489)
 position = Vector2(132, 408)
 
 [node name="deck_collision10" parent="Container" instance=ExtResource("5_xtag3")]
-position = Vector2(606, 132)
+position = Vector2(642, 79)
 
 [node name="deck_collision11" parent="Container" instance=ExtResource("5_xtag3")]
-position = Vector2(309, 68)
+position = Vector2(309, 34)
 
 [node name="deck_collision12" parent="Container" instance=ExtResource("5_xtag3")]
-position = Vector2(1189, 321)
+position = Vector2(1259, 368)
 
 [connection signal="pressed" from="Deck" to="." method="_on_deck_pressed"]
 [connection signal="pressed" from="Draw" to="." method="_on_draw_pressed"]


### PR DESCRIPTION
# Dragging
The player can now drag their cards. I have collisions in place for the decks but will need to connect the card_ui to the collision_deck to make them pop in place.
 
![image](https://github.com/JaceLearnsPython/GoDot/assets/85045390/769311ef-04df-43da-8c0b-f418e07869e6)

## Issues
- Players cannot unstack cards. The card they click on will "eat" the other cards by stacking on top and there is no way to drag the top card off currently as it treats the stack as 1 card.

## Next up!
- fix bug
- add drop functionality to drop the cards into a deck pile