### PR TITLE
Pause button 

### DIFF
--- a/card_ui/card_ui.gd
+++ b/card_ui/card_ui.gd
@@ -18,7 +18,6 @@ func _process(delta):
 			
 func card_played():
 		card_num = str($TextureRect.texture.get_path())
-		#var played_card = card_num
 		card_num = card_num.split("_")
 		
 		# check if it is an empty stack

--- a/pause_game/paused.gd
+++ b/pause_game/paused.gd
@@ -1,0 +1,11 @@
+extends ColorRect
+
+func _on_resume_pressed():
+	get_tree().paused = false
+	hide()
+
+
+func _on_quit_pressed():
+	get_tree().paused = false
+	get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+

--- a/pause_game/paused.tscn
+++ b/pause_game/paused.tscn
@@ -1,0 +1,52 @@
+[gd_scene load_steps=3 format=3 uid="uid://b1btfbuvvx1oi"]
+
+[ext_resource type="FontFile" uid="uid://botdo7sojue6e" path="res://ass/RubikMonoOne-Regular.ttf" id="1_orrfq"]
+[ext_resource type="Script" path="res://pause_game/paused.gd" id="1_rvr14"]
+
+[node name="Paused" type="ColorRect"]
+process_mode = 2
+visible = false
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
+color = Color(0.129412, 0.129412, 0.129412, 0.431373)
+script = ExtResource("1_rvr14")
+metadata/_edit_use_anchors_ = true
+
+[node name="resume" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -125.0
+offset_top = -20.0
+offset_right = 125.0
+offset_bottom = 20.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_fonts/font = ExtResource("1_orrfq")
+text = "Resume"
+metadata/_edit_use_anchors_ = true
+
+[node name="quit" type="Button" parent="."]
+layout_mode = 1
+anchors_preset = 8
+anchor_left = 0.5
+anchor_top = 0.5
+anchor_right = 0.5
+anchor_bottom = 0.5
+offset_left = -125.0
+offset_top = 34.0
+offset_right = 125.0
+offset_bottom = 74.0
+grow_horizontal = 2
+grow_vertical = 2
+theme_override_fonts/font = ExtResource("1_orrfq")
+text = "Main Menu"
+
+[connection signal="pressed" from="resume" to="." method="_on_resume_pressed"]
+[connection signal="pressed" from="quit" to="." method="_on_quit_pressed"]

--- a/project.godot
+++ b/project.godot
@@ -37,6 +37,11 @@ left-click={
 "events": [Object(InputEventMouseButton,"resource_local_to_scene":false,"resource_name":"","device":-1,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"button_mask":0,"position":Vector2(0, 0),"global_position":Vector2(0, 0),"factor":1.0,"button_index":1,"canceled":false,"pressed":false,"double_click":false,"script":null)
 ]
 }
+pause={
+"deadzone": 0.5,
+"events": [Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"window_id":0,"alt_pressed":false,"shift_pressed":false,"ctrl_pressed":false,"meta_pressed":false,"pressed":false,"keycode":0,"physical_keycode":4194305,"key_label":0,"unicode":0,"echo":false,"script":null)
+]
+}
 
 [layer_names]
 

--- a/scenes/AI_script.gd
+++ b/scenes/AI_script.gd
@@ -197,7 +197,7 @@ func check_game_end():
 func end_the_game():
 	# score the points to the 'main' leaderboard in SW
 
-	# SW requires disctionary
+	# SW requires disctionary for metadata
 	var metadata : Dictionary = {"time" : "TIME TBD"}
 	
 	# check who won and act accordingly

--- a/scenes/SinglePlayer.gd
+++ b/scenes/SinglePlayer.gd
@@ -27,8 +27,6 @@ var points_needed_to_win = 10
 
 const blitz_pile_size = 10 # All players start with 10 cards in the blitz pile
 
-# make a random num generator
-var random = RandomNumberGenerator.new()
 
 # On scene Load
 func _ready():
@@ -70,7 +68,7 @@ func _process(delta):
 				node.texture = load("res://ass/cards/card" + played_card + ".png")
 				
 				# keep track of score
-				if i == 3:
+				if i != 4:
 					blitz_played +=1
 					num_of_played+=1
 					return
@@ -86,9 +84,7 @@ func remove_card(card):
 	
 	var i = player_deck.find(card)
 	if player_deck.find(card) != -1:
-		print("deck contains dupe")
 		player_deck.remove_at(i)
-		print("Removed.\n")
 
 # make the deck, shuffle it, return it.
 func make_deck(deck):
@@ -118,15 +114,18 @@ func starting_deal(player):
 
 # DRAW BUTTON
 func _on_draw_pressed():
-	# need to change to not be random and treat it like a stack
+
+	# check the index
 	if player_deck_index >= player_deck.size() - 1:
 		player_deck_index = 0
 	
+	# update card
 	var card = "res://ass/cards/card" + player_deck[player_deck_index] + ".png"
 	card = load(card)
 	$Player1/DeckCard/TextureRect.texture = card
 	player_deck_index +=3
 
-# Add the options to leave
-func _on_back_button_pressed():
-		get_tree().change_scene_to_file("res://scenes/MainMenu.tscn")
+func _on_pause_button_pressed():
+	get_tree().paused = true
+	get_node("Paused").visible = true
+	

--- a/scenes/SinglePlayer.tscn
+++ b/scenes/SinglePlayer.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=8 format=3 uid="uid://b88dv4vkljkq3"]
+[gd_scene load_steps=9 format=3 uid="uid://b88dv4vkljkq3"]
 
 [ext_resource type="Texture2D" uid="uid://0qkpb0yht1fv" path="res://ass/poker_background.jpg" id="1_irmfp"]
 [ext_resource type="Script" path="res://scenes/SinglePlayer.gd" id="1_ruqbv"]
@@ -7,12 +7,14 @@
 [ext_resource type="Texture2D" uid="uid://ben7qqx34vpkq" path="res://ass/cards/card_back.png" id="5_f35wx"]
 [ext_resource type="PackedScene" uid="uid://dda64qmj6m6ts" path="res://card_collision/card_collision.tscn" id="5_xtag3"]
 [ext_resource type="FontFile" uid="uid://botdo7sojue6e" path="res://ass/RubikMonoOne-Regular.ttf" id="5_ycoew"]
+[ext_resource type="PackedScene" uid="uid://b1btfbuvvx1oi" path="res://pause_game/paused.tscn" id="8_lyjkx"]
 
 [node name="SinglePlayer" type="Node2D"]
 position = Vector2(0, -5)
 script = ExtResource("1_ruqbv")
 
 [node name="Background" type="TextureRect" parent="."]
+process_mode = 3
 offset_right = 1920.0
 offset_bottom = 1087.0
 size_flags_vertical = 4
@@ -130,13 +132,13 @@ script = null
 position = Vector2(1165, 8)
 script = null
 
-[node name="Back_Button" type="Button" parent="."]
+[node name="pause_button" type="Button" parent="."]
 offset_left = 11.0
 offset_top = 26.0
 offset_right = 211.0
 offset_bottom = 66.0
 theme_override_fonts/font = ExtResource("5_ycoew")
-text = "Leave Game"
+text = "Pause Game"
 metadata/_edit_use_anchors_ = true
 
 [node name="Container" type="BoxContainer" parent="."]
@@ -260,5 +262,9 @@ offset_bottom = 248.0
 scale = Vector2(0.6, 0.6)
 texture = ExtResource("5_f35wx")
 
+[node name="Paused" parent="." instance=ExtResource("8_lyjkx")]
+offset_right = 1920.0
+offset_bottom = 1100.0
+
 [connection signal="pressed" from="Draw" to="." method="_on_draw_pressed"]
-[connection signal="pressed" from="Back_Button" to="." method="_on_back_button_pressed"]
+[connection signal="pressed" from="pause_button" to="." method="_on_pause_button_pressed"]

--- a/scenes/get_name.gd
+++ b/scenes/get_name.gd
@@ -8,6 +8,11 @@ func _ready():
 func _on_text_submitted(new_text):
 	var get_name_node = get_node(".")
 	var player_name = new_text.to_upper() # make it all caps
+	
+	# prevent empty names
+	if player_name.length() <= 0:
+		get_name_node.placeholder_text = "All who enter must type at least a character :)"
+		return
 	player_name.strip_edges() # trim whitespace
 	ChangeToSinglePlayer.player_name = player_name
 	%display_name.text += player_name


### PR DESCRIPTION
TLDR: Implemented pause button. The game can now be paused and a menu will popup allowing you to resume and quit.

# Pause Button
The pause button replaces the old quit button. It now present a menu with the option to resume and quit. It also gray scales the background a bit (not the cards, might change later)
![image](https://github.com/user-attachments/assets/c6ca3ea7-f3cf-44fe-9632-37ca8a239110)


![image](https://github.com/user-attachments/assets/2a7c5588-cf00-49da-a73a-504aa25c2485)


# Update to Get_name
The old way of getting the name did not check for empty strings. It now checks and updates the message to ask for a name.
![image](https://github.com/user-attachments/assets/8a27bcec-9154-427b-9e7e-f7f07e47aaa2)

Updated:
![image](https://github.com/user-attachments/assets/89fee208-8fc7-4dd3-8caf-826fd72ef2bf)
