### PR TITLE
Updated the way the scorer is counted. 

### DIFF
--- a/scenes/AI_script.gd
+++ b/scenes/AI_script.gd
@@ -218,8 +218,15 @@ func end_the_game():
 	else:
 		ChangeToSinglePlayer.player_won = false
 	
+	# since we are just subtracting 1 in the singleplayer script, we need to make sure we don't go negative
+	# as that would not make sense for the rules of the game
+	if blitz_pile_size < 0:
+		blitz_pile_size = 0
+	
 	# record the score for player.
-	ChangeToSinglePlayer.score = num_of_played - (10 - blitz_played) # recall the -1 for each card left in blitz pile rule
+	# remember that the final score is counted against the remaining cards in the blitz pile @blitz_pile_size.
+	# i.e. If you play all cards in your blitz pile, you would get total score - 0
+	ChangeToSinglePlayer.score = num_of_played - (blitz_pile_size - blitz_played) 
 	
 	# add child to keep it in the tree
 	add_child(SilentWolf.Scores.save_score(ChangeToSinglePlayer.player_name, ChangeToSinglePlayer.score, "main", metadata))

--- a/scenes/SinglePlayer.gd
+++ b/scenes/SinglePlayer.gd
@@ -25,7 +25,7 @@ var played_cards = []
 # used in AI script to see if the player won
 var points_needed_to_win = 10
 
-const blitz_pile_size = 10 # All players start with 10 cards in the blitz pile
+var blitz_pile_size = 10 # All players start with 10 cards in the blitz pile
 
 @onready var unix_start_time = Time.get_unix_time_from_system()
 
@@ -78,6 +78,7 @@ func _process(delta):
 				# keep track of score
 				if i != 4:
 					blitz_played +=1
+					blitz_pile_size -= 1
 					num_of_played+=1
 					return
 				else:


### PR DESCRIPTION
I was subtracting a static 10 from the score but that does not make sense.

When you play a blitz card in the game, you take a card from the blitz pile and score a point, so if you play 1 blitz card it would be -8 cause you would subtract 9 from the 1 point cause the blitz pile gets smaller as you play

Now the scoring system is accurate to the game Brot blitz is based off of (Dutch Blitz)